### PR TITLE
feat(media): add 'clip' method

### DIFF
--- a/src/fastedit/core/Media.py
+++ b/src/fastedit/core/Media.py
@@ -157,3 +157,63 @@ class _Media:
         )
         media_metadata = self.__refactor_ffprobe_data(ffprobe_metadata)
         return media_metadata
+
+    def __move_and_replace(
+        self
+    ):
+        """
+        Moving second file to main file
+        """
+        shutil.move(
+            src=self._second_temp_file,
+            dst=self._main_temp_file
+        )
+
+    def clip(
+        self,
+        start: float,
+        end: float
+    ):
+        """
+        Extracts a portion of the video.
+
+        Parameters
+        ----------
+        start: float
+            Start time of the clip in seconds.
+        end: float
+            End time of the clip in seconds.
+        """
+        # Verifying parameters types
+        if not isinstance(start, (float, int)):
+            raise TypeError(
+                f"Expected 'start' to be of type 'float' or 'int', but got "
+                f"'{type(start).__name__}' instead."
+            )
+        if not isinstance(end, (float, int)):
+            raise TypeError(
+                f"Expected 'end' to be of type 'float' or 'int', but got "
+                f"'{type(start).__name__}' instead."
+            )
+        # Trimming input video
+        input = ffmpeg.input(
+            filename=self._main_temp_file,
+            ss=start,
+            to=end
+        )
+        # Defining output and codec copying
+        output = ffmpeg.output(
+            input,
+            self._second_temp_file,
+            c="copy"
+        )
+        overwrite = ffmpeg.overwrite_output(
+            output
+        )
+        # Running command
+        ffmpeg.run(
+            stream_spec=overwrite,
+            quiet=True
+        )
+        # Saving result to main file
+        self.__move_and_replace()

--- a/src/fastedit/core/Media.py
+++ b/src/fastedit/core/Media.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import ffmpeg
+from typing import Union
 from tempfile import TemporaryDirectory
 from fastedit.core.utils import _guess_file_type
 
@@ -171,8 +172,8 @@ class _Media:
 
     def clip(
         self,
-        start: float,
-        end: float
+        start: Union[int, float],
+        end: Union[int, float]
     ):
         """
         Extracts a portion of the video.
@@ -183,6 +184,11 @@ class _Media:
             Start time of the clip in seconds.
         end: float
             End time of the clip in seconds.
+
+        Raises
+        ------
+        TypeError
+            If start or end are not int or float.
         """
         # Verifying parameters types
         if not isinstance(start, (float, int)):

--- a/tests/unit/video_test.py
+++ b/tests/unit/video_test.py
@@ -54,7 +54,8 @@ def test_video_metadata_without_ffprobe(monkeypatch):
     )
     assert str(error.value) == expected_error
 
-def test_video_cut():
+
+def test_video_cut_int_int():
     video = Video(test_files[0])
     video.clip(
         start=0,
@@ -66,6 +67,49 @@ def test_video_cut():
     assert len(output["streams"]) == 2
     assert output["streams"][0]["codec_name"] == "h264"
     assert output["streams"][1]["codec_name"] == "aac"
+
+
+def test_video_cut_int_float():
+    video = Video(test_files[0])
+    video.clip(
+        start=0,
+        end=10.1
+    )
+    output = video.metadata()
+    assert output["format_name"] == "mov,mp4,m4a,3gp,3g2,mj2"
+    assert int(float(output["duration"])) == 10
+    assert len(output["streams"]) == 2
+    assert output["streams"][0]["codec_name"] == "h264"
+    assert output["streams"][1]["codec_name"] == "aac"
+
+
+def test_video_cut_float_int():
+    video = Video(test_files[0])
+    video.clip(
+        start=0.1,
+        end=10
+    )
+    output = video.metadata()
+    assert output["format_name"] == "mov,mp4,m4a,3gp,3g2,mj2"
+    assert int(float(output["duration"])) == 10
+    assert len(output["streams"]) == 2
+    assert output["streams"][0]["codec_name"] == "h264"
+    assert output["streams"][1]["codec_name"] == "aac"
+
+
+def test_video_cut_float_float():
+    video = Video(test_files[0])
+    video.clip(
+        start=0.1,
+        end=10.2
+    )
+    output = video.metadata()
+    assert output["format_name"] == "mov,mp4,m4a,3gp,3g2,mj2"
+    assert int(float(output["duration"])) == 10
+    assert len(output["streams"]) == 2
+    assert output["streams"][0]["codec_name"] == "h264"
+    assert output["streams"][1]["codec_name"] == "aac"
+
 
 def test_video_cut_without_ffmpeg(monkeypatch):
     # Mocking FFmpeg not installed

--- a/tests/unit/video_test.py
+++ b/tests/unit/video_test.py
@@ -53,3 +53,40 @@ def test_video_metadata_without_ffprobe(monkeypatch):
         "ffprobe error (see stderr output for detail)"
     )
     assert str(error.value) == expected_error
+
+def test_video_cut():
+    video = Video(test_files[0])
+    video.clip(
+        start=0,
+        end=10
+    )
+    output = video.metadata()
+    assert output["format_name"] == "mov,mp4,m4a,3gp,3g2,mj2"
+    assert int(float(output["duration"])) == 10
+    assert len(output["streams"]) == 2
+    assert output["streams"][0]["codec_name"] == "h264"
+    assert output["streams"][1]["codec_name"] == "aac"
+
+def test_video_cut_without_ffmpeg(monkeypatch):
+    # Mocking FFmpeg not installed
+    def mock_ffmpeg(*args, **kwargs):
+        raise ffmpeg.Error(
+            "ffmpeg",
+            "stdout",
+            "stderr"
+        )
+
+    # Replace ffmpeg.run by mocking
+    monkeypatch.setattr(ffmpeg, "run", mock_ffmpeg)
+
+    # Testing
+    video = Video(test_files[0])
+    with pytest.raises(ffmpeg.Error) as error:
+        video.clip(
+            start=0,
+            end=10
+        )
+    expected_error = (
+        "ffmpeg error (see stderr output for detail)"
+    )
+    assert str(error.value) == expected_error


### PR DESCRIPTION
- Created the `clip` method in the `_Media` class to extract a sub-part of a video.
- Added the `__move_and_replace` method to handle placing transformation results in the main temporary file.