### PR TITLE
feat(video): add 'text' method

### DIFF
--- a/src/fastedit/io/Video.py
+++ b/src/fastedit/io/Video.py
@@ -295,10 +295,10 @@ class Video(_Media):
         self,
         x: int,
         y: int,
+        text: str,
         start: Union[int, float],
         end: Union[int, float],
-        text: str,
-        fontfile: str = "",
+        fontfile: str = None,
         fontsize: int = 24,
         fontcolor: str = "white",
         borderw: int = 5,
@@ -308,7 +308,93 @@ class Video(_Media):
         boxcolor: str = "black"
     ):
         """
+        Add text to the video at specific coordinates and duration.
+
+        Parameters
+        ----------
+        x: int
+            The x-coordinate for the text's position on the video.
+        y: int
+            The y-coordinate for the text's position on the video.
+        text: str
+            The content of the text to be rendered on the video.
+        start: int or float
+            The start time (in seconds) from when the text will appear on the 
+            video.
+        end: int or float
+            The end time (in seconds) when the text will disappear from the 
+            video.
+        fontfile: str, optional
+            The path to the font file to be used for the text.
+        fontsize: int, optional
+            The font size to be used for the text. Default is 24.
+        fontcolor: str, optional
+            The color of the text. Default is "white".
+        borderw: int, optional
+            The width of the border around the text. Default is 5.
+        bordercolor: str, optional
+            The color of the border around the text. Default is "black".
+        box: bool, optional
+            Whether to draw a box around the text using the background color. 
+            Default is False.
+        boxborderw: int, optional
+            The width of the border around the box. Default is 5.
+        boxcolor: str, optional
+            The color of the box around the text. Default is "black".
+
+        Raises
+        ------
+        TypeError
+            If `x` is not an int.
+            If `y` is not an int.
+            If `text` is not a str.
+            If `start` is not an int or float.
+            If `end` is not an int or float.
+        ValueError
+            If `end` is not strictly greater than `start`.
+            If `end` is strictly greater than media duration.
         """
+        # Verifying parameters types
+        if not isinstance(x, int):
+            raise TypeError(
+                f"Expected 'x' to be of type 'int', but got "
+                f"'{type(x).__name__}' instead."
+            )
+        if not isinstance(y, int):
+            raise TypeError(
+                f"Expected 'y' to be of type 'int', but got "
+                f"'{type(y).__name__}' instead."
+            )
+        if not isinstance(text, str):
+            raise TypeError(
+                f"Expected 'text' to be of type 'str', but got "
+                f"'{type(text).__name__}' instead."
+            )
+        if not isinstance(start, (int, float)):
+            raise TypeError(
+                f"Expected 'start' to be of type 'int' or 'float', but got "
+                f"'{type(start).__name__}' instead."
+            )
+        if not isinstance(end, (int, float)):
+            raise TypeError(
+                f"Expected 'end' to be of type 'int' or 'float', but got "
+                f"'{type(end).__name__}' instead."
+            )
+        # Verifying parameters consistency
+        if not end > start:
+            raise ValueError(
+                f"Invalid 'end' value: 'end' must be strictly greater than "
+                f"'start'. Got start={start} and end={end}."
+            )
+        metadata = self.metadata()
+        media_duration = float(metadata["duration"])
+        if not end <= media_duration:
+            raise ValueError(
+                f"Invalid 'end' value: 'end' must be less than or equal to "
+                f"the media duration. Got end={end}, but media duration is "
+                f"{media_duration}."
+            )
+        # Boolean to 0 | 1
         box_enabled = int(box == True)
         # Input video
         input = ffmpeg.input(

--- a/src/fastedit/io/Video.py
+++ b/src/fastedit/io/Video.py
@@ -290,3 +290,58 @@ class Video(_Media):
         )
         # Saving result to main file
         self._move_and_replace()
+
+    def text(
+        self,
+        x: int,
+        y: int,
+        start: Union[int, float],
+        end: Union[int, float],
+        text: str,
+        fontfile: str = "",
+        fontsize: int = 24,
+        fontcolor: str = "white",
+        borderw: int = 5,
+        bordercolor: str = "black",
+        box: bool = False,
+        boxborderw: int = 5,
+        boxcolor: str = "black"
+    ):
+        """
+        """
+        box_enabled = int(box == True)
+        # Input video
+        input = ffmpeg.input(
+            filename=self._main_temp_file
+        )
+        # Text in video
+        zoom = ffmpeg.drawtext(
+            input,
+            x=f"{x}-(text_w)/2",
+            y=f"{y}-(text_h)/2",
+            text=text,
+            enable=f"between(t,{start},{end})",
+            fontfile=fontfile,
+            fontsize=fontsize,
+            fontcolor=fontcolor,
+            borderw=borderw,
+            bordercolor=bordercolor,
+            box=box_enabled,
+            boxborderw=boxborderw,
+            boxcolor=boxcolor
+        )
+        # Defining output and codec copying
+        output = ffmpeg.output(
+            zoom,
+            self._second_temp_file
+        )
+        overwrite = ffmpeg.overwrite_output(
+            output
+        )
+        # Running command
+        ffmpeg.run(
+            stream_spec=overwrite,
+            quiet=True
+        )
+        # Saving result to main file
+        self._move_and_replace()

--- a/src/fastedit/io/Video.py
+++ b/src/fastedit/io/Video.py
@@ -325,22 +325,28 @@ class Video(_Media):
             The end time (in seconds) when the text will disappear from the
             video.
         fontfile: str, optional
-            The path to the font file to be used for the text.
+            The path to the font file to be used for the text. Default is
+            None.
         fontsize: int, optional
             The font size to be used for the text. Default is 24.
         fontcolor: str, optional
-            The color of the text. Default is "white".
+            The color of the text. Default is "white". The set of possible
+            values at https://ffmpeg.org/ffmpeg-utils.html#color-syntax.
         borderw: int, optional
             The width of the border around the text. Default is 5.
         bordercolor: str, optional
-            The color of the border around the text. Default is "black".
+            The color of the border around the text. Default is "black". The
+            set of possible values at
+            https://ffmpeg.org/ffmpeg-utils.html#color-syntax.
         box: bool, optional
             Whether to draw a box around the text using the background color.
             Default is False.
         boxborderw: int, optional
             The width of the border around the box. Default is 5.
         boxcolor: str, optional
-            The color of the box around the text. Default is "black".
+            The color of the box around the text. Default is "black". The set
+            of possible values at
+            https://ffmpeg.org/ffmpeg-utils.html#color-syntax.
 
         Raises
         ------

--- a/src/fastedit/io/Video.py
+++ b/src/fastedit/io/Video.py
@@ -319,10 +319,10 @@ class Video(_Media):
         text: str
             The content of the text to be rendered on the video.
         start: int or float
-            The start time (in seconds) from when the text will appear on the 
+            The start time (in seconds) from when the text will appear on the
             video.
         end: int or float
-            The end time (in seconds) when the text will disappear from the 
+            The end time (in seconds) when the text will disappear from the
             video.
         fontfile: str, optional
             The path to the font file to be used for the text.
@@ -335,7 +335,7 @@ class Video(_Media):
         bordercolor: str, optional
             The color of the border around the text. Default is "black".
         box: bool, optional
-            Whether to draw a box around the text using the background color. 
+            Whether to draw a box around the text using the background color.
             Default is False.
         boxborderw: int, optional
             The width of the border around the box. Default is 5.
@@ -395,7 +395,7 @@ class Video(_Media):
                 f"{media_duration}."
             )
         # Boolean to 0 | 1
-        box_enabled = int(box == True)
+        box_enabled = int(box)
         # Input video
         input = ffmpeg.input(
             filename=self._main_temp_file
@@ -419,6 +419,7 @@ class Video(_Media):
         # Defining output and codec copying
         output = ffmpeg.output(
             zoom,
+            input.audio,
             self._second_temp_file
         )
         overwrite = ffmpeg.overwrite_output(


### PR DESCRIPTION
Added 'text' method to overlay text on video at specified coordinates (x, y) and duration.