### PR TITLE
feat(video): add 'add_audio' method

### DIFF
--- a/src/fastedit/io/Video.py
+++ b/src/fastedit/io/Video.py
@@ -445,6 +445,32 @@ class Video(_Media):
         audio: Audio,
         strategy: str
     ):
+        """
+        Adds an audio track to the video using a specified strategy.
+
+        Parameters
+        ----------
+        audio: Audio
+            The new audio to be added to the video. This should be an instance
+            of the `Audio` class.
+        strategy: str
+            The strategy for handling the audio merge. Must be one of the
+            following:
+            - "replace": Replaces the existing audio track with the new one.
+            - "add": Adds a new audio track to the video.
+            - "mix": Mixes the new audio track with the existing one.
+                
+        Raises
+        ------
+        TypeError
+            If `audio` is not an instance of `Audio`.
+            If `strategy` is not a string.
+        ValueError
+            If `strategy` is not one of the valid options: "replace", "add",
+            or "mix".
+        NameError
+            If the specified strategy is not found in the strategy mapping.
+        """
         # Verifying parameters types
         if not isinstance(audio, Audio):
             raise TypeError(

--- a/src/fastedit/io/Video.py
+++ b/src/fastedit/io/Video.py
@@ -459,7 +459,7 @@ class Video(_Media):
             - "replace": Replaces the existing audio track with the new one.
             - "add": Adds a new audio track to the video.
             - "mix": Mixes the new audio track with the existing one.
-                
+
         Raises
         ------
         TypeError
@@ -487,7 +487,7 @@ class Video(_Media):
         if strategy not in valid_strategies:
             raise ValueError(
                 f"Invalid strategy '{strategy}'. Expected one of: "
-                f"{', '.join(valid_strategies)}"
+                f"{', '.join(valid_strategies)}."
             )
         # Input video and audio
         input_video = ffmpeg.input(
@@ -496,8 +496,8 @@ class Video(_Media):
         input_audio = ffmpeg.input(
             filename=audio._main_temp_file
         )
+        # Replacing audio
         if strategy == valid_strategies[0]:
-            # Defining output and codec copying
             output = ffmpeg.output(
                 input_video.video,
                 input_audio.audio,
@@ -505,8 +505,16 @@ class Video(_Media):
                 shortest=None,
                 vcodec="copy"
             )
+        # Adding audio
         elif strategy == valid_strategies[1]:
-            pass
+            output = ffmpeg.output(
+                input_video,
+                input_audio.audio,
+                self._second_temp_file,
+                shortest=None,
+                vcodec="copy"
+            )
+        # Mixing audio
         elif strategy == valid_strategies[2]:
             pass
         else:

--- a/src/fastedit/io/Video.py
+++ b/src/fastedit/io/Video.py
@@ -2,6 +2,7 @@ import math
 import ffmpeg
 from typing import Union
 from fastedit.core.Media import _Media
+from fastedit.io.Audio import Audio
 from fastedit.core.utils import _guess_file_type
 
 
@@ -428,6 +429,65 @@ class Video(_Media):
             input.audio,
             self._second_temp_file
         )
+        overwrite = ffmpeg.overwrite_output(
+            output
+        )
+        # Running command
+        ffmpeg.run(
+            stream_spec=overwrite,
+            quiet=True
+        )
+        # Saving result to main file
+        self._move_and_replace()
+
+    def add_audio(
+        self,
+        audio: Audio,
+        strategy: str
+    ):
+        # Verifying parameters types
+        if not isinstance(audio, Audio):
+            raise TypeError(
+                f"Expected 'audio' to be of type 'Audio', but got "
+                f"'{type(audio).__name__}' instead."
+            )
+        if not isinstance(strategy, str):
+            raise TypeError(
+                f"Expected 'strategy' to be of type 'str', but got "
+                f"'{type(strategy).__name__}' instead."
+            )
+        # Verifying parameters consistency
+        valid_strategies = ["replace", "add", "mix"]
+        if strategy not in valid_strategies:
+            raise ValueError(
+                f"Invalid strategy '{strategy}'. Expected one of: "
+                f"{', '.join(valid_strategies)}"
+            )
+        # Input video and audio
+        input_video = ffmpeg.input(
+            filename=self._main_temp_file
+        )
+        input_audio = ffmpeg.input(
+            filename=audio._main_temp_file
+        )
+        if strategy == valid_strategies[0]:
+            # Defining output and codec copying
+            output = ffmpeg.output(
+                input_video.video,
+                input_audio.audio,
+                self._second_temp_file,
+                shortest=None,
+                vcodec="copy"
+            )
+        elif strategy == valid_strategies[1]:
+            pass
+        elif strategy == valid_strategies[2]:
+            pass
+        else:
+            raise NameError(
+                "Strategy not found"
+            )
+        # Overwrite output file
         overwrite = ffmpeg.overwrite_output(
             output
         )

--- a/src/fastedit/io/Video.py
+++ b/src/fastedit/io/Video.py
@@ -516,7 +516,26 @@ class Video(_Media):
             )
         # Mixing audio
         elif strategy == valid_strategies[2]:
-            pass
+            # Mixing audios
+            mixed_audio = ffmpeg.filter(
+                [
+                    input_video.audio,
+                    input_audio.audio
+                ],
+                filter_name="amix",
+                duration="shortest"
+            )
+            # Merging video and mixed audios
+            merged = ffmpeg.concat(
+                input_video,
+                mixed_audio,
+                v=1,
+                a=1
+            )
+            output = ffmpeg.output(
+                merged,
+                self._second_temp_file
+            )
         else:
             raise NameError(
                 "Strategy not found"

--- a/tests/unit/video_test.py
+++ b/tests/unit/video_test.py
@@ -824,3 +824,20 @@ def test_video_add_audio_add_strategy():
     assert output["streams"][1]["codec_name"] == "aac"
     assert output["streams"][0]["height"] == 1080
     assert output["streams"][0]["width"] == 1920
+
+
+def test_video_add_audio_mix_strategy():
+    video = Video(test_files[0])
+    audio = Audio(test_files[1])
+    video.add_audio(
+        audio=audio,
+        strategy="mix"
+    )
+    output = video.metadata()
+    assert output["format_name"] == "mov,mp4,m4a,3gp,3g2,mj2"
+    assert int(float(output["duration"])) == 15
+    assert len(output["streams"]) == 2
+    assert output["streams"][1]["codec_name"] == "h264"
+    assert output["streams"][0]["codec_name"] == "aac"
+    assert output["streams"][1]["height"] == 1080
+    assert output["streams"][1]["width"] == 1920

--- a/tests/unit/video_test.py
+++ b/tests/unit/video_test.py
@@ -1,4 +1,5 @@
 from fastedit.io.Video import Video
+from fastedit.io.Audio import Audio
 import ffmpeg
 import pytest
 
@@ -740,6 +741,85 @@ def test_video_text_working():
     assert output["format_name"] == "mov,mp4,m4a,3gp,3g2,mj2"
     assert int(float(output["duration"])) == 15
     assert len(output["streams"]) == 2
+    assert output["streams"][0]["codec_name"] == "h264"
+    assert output["streams"][1]["codec_name"] == "aac"
+    assert output["streams"][0]["height"] == 1080
+    assert output["streams"][0]["width"] == 1920
+
+
+def test_video_add_audio_wrong_audio_type_parameter():
+    video = Video(test_files[0])
+    audio = "test"
+    with pytest.raises(TypeError) as error:
+        video.add_audio(
+            audio=audio,
+            strategy="replace"
+        )
+    expected_error = (
+        "Expected 'audio' to be of type 'Audio', but got "
+        "'str' instead."
+    )
+    assert str(error.value) == expected_error
+
+
+def test_video_add_audio_wrong_strategy_type_parameter():
+    video = Video(test_files[0])
+    audio = Audio(test_files[1])
+    with pytest.raises(TypeError) as error:
+        video.add_audio(
+            audio=audio,
+            strategy=1
+        )
+    expected_error = (
+        "Expected 'strategy' to be of type 'str', but got "
+        "'int' instead."
+    )
+    assert str(error.value) == expected_error
+
+
+def test_video_add_audio_strategy_not_valid():
+    video = Video(test_files[0])
+    audio = Audio(test_files[1])
+    with pytest.raises(ValueError) as error:
+        video.add_audio(
+            audio=audio,
+            strategy="strat1"
+        )
+    expected_error = (
+        "Invalid strategy 'strat1'. Expected one of: "
+        "replace, add, mix."
+    )
+    assert str(error.value) == expected_error
+
+
+def test_video_add_audio_replace_strategy():
+    video = Video(test_files[0])
+    audio = Audio(test_files[1])
+    video.add_audio(
+        audio=audio,
+        strategy="replace"
+    )
+    output = video.metadata()
+    assert output["format_name"] == "mov,mp4,m4a,3gp,3g2,mj2"
+    assert int(float(output["duration"])) == 15
+    assert len(output["streams"]) == 2
+    assert output["streams"][0]["codec_name"] == "h264"
+    assert output["streams"][1]["codec_name"] == "aac"
+    assert output["streams"][0]["height"] == 1080
+    assert output["streams"][0]["width"] == 1920
+
+
+def test_video_add_audio_add_strategy():
+    video = Video(test_files[0])
+    audio = Audio(test_files[1])
+    video.add_audio(
+        audio=audio,
+        strategy="add"
+    )
+    output = video.metadata()
+    assert output["format_name"] == "mov,mp4,m4a,3gp,3g2,mj2"
+    assert int(float(output["duration"])) == 15
+    assert len(output["streams"]) == 3
     assert output["streams"][0]["codec_name"] == "h264"
     assert output["streams"][1]["codec_name"] == "aac"
     assert output["streams"][0]["height"] == 1080


### PR DESCRIPTION
- Implement 'add_audio' method to merge an audio track into a video
- Supports three strategies: 'replace', 'add', and 'mix'