### PR TITLE
feat(video): add 'add_subtitles' method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install FFmpeg
-        run: sudo apt update && sudo apt install ffmpeg -y
+      - name: Download and install FFmpeg
+        run: |
+          # Creating FFmpeg directory
+          mkdir -p $HOME/ffmpeg
+          cd $HOME/ffmpeg
+
+          # Downloading FFmpeg
+          wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-7.0.2-arm64-static.tar.xz
+          
+          # Extraire l'archive
+          tar -xf ffmpeg-7.0.2-arm64-static.tar.xz --strip-components=1
+          
+          # Add directory to $PATH
+          echo "$HOME/ffmpeg" >> $GITHUB_PATH
       - name: Verify FFmpeg installation
         run: ffmpeg -version
       - name: Upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-7.0.2-amd64-static.tar.xz
           
           # Extraire l'archive
-          tar -xf ffmpeg-7.0.2-arm64-static.tar.xz --strip-components=1
+          tar -xf ffmpeg-7.0.2-amd64-static.tar.xz --strip-components=1
           
           # Add directory to $PATH
           echo "$HOME/ffmpeg" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - 'main'
 
-env:
-  FFMPEG_BIN_DIR: /usr/local/bin
-
 jobs:
   Test:
     runs-on: ubuntu-latest
@@ -22,7 +19,7 @@ jobs:
           # Downloading FFmpeg
           wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-7.0.2-amd64-static.tar.xz
           
-          # Extraire l'archive
+          # Archive extraction
           tar -xf ffmpeg-7.0.2-amd64-static.tar.xz --strip-components=1
           
           # Add directory to $PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           cd $HOME/ffmpeg
 
           # Downloading FFmpeg
-          wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-7.0.2-arm64-static.tar.xz
+          wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-7.0.2-amd64-static.tar.xz
           
           # Extraire l'archive
           tar -xf ffmpeg-7.0.2-arm64-static.tar.xz --strip-components=1

--- a/src/fastedit/core/Base.py
+++ b/src/fastedit/core/Base.py
@@ -55,3 +55,14 @@ class _Base:
             path,
             self._main_temp_file
         )
+
+    def _move_and_replace(
+        self
+    ):
+        """
+        Moving second file to main file.
+        """
+        shutil.move(
+            src=self._second_temp_file,
+            dst=self._main_temp_file
+        )

--- a/src/fastedit/core/Media.py
+++ b/src/fastedit/core/Media.py
@@ -122,17 +122,6 @@ class _Media(_Base):
         media_metadata = self.__refactor_ffprobe_data(ffprobe_metadata)
         return media_metadata
 
-    def _move_and_replace(
-        self
-    ):
-        """
-        Moving second file to main file
-        """
-        shutil.move(
-            src=self._second_temp_file,
-            dst=self._main_temp_file
-        )
-
     def clip(
         self,
         start: Union[int, float],

--- a/src/fastedit/io/Subtitles.py
+++ b/src/fastedit/io/Subtitles.py
@@ -1,5 +1,7 @@
 from fastedit.core.Base import _Base
 from fastedit.core.utils import _guess_file_type
+import ffmpeg
+import os
 
 
 class Subtitles(_Base):
@@ -32,3 +34,41 @@ class Subtitles(_Base):
             )
         # Initialize instance
         super().__init__(path)
+        self._change_to_ass()
+
+    def _change_to_ass(
+        self
+    ):
+        """
+        Change subtitles format to ASS.
+        """
+        extension = ".ass"
+        # Changing second temp file format
+        self._second_temp_file = os.path.join(
+            self._temp_dir.name,
+            "second" + extension
+        )
+        # Changing subtitles format
+        input = ffmpeg.input(
+            filename=self._main_temp_file
+        )
+        output = ffmpeg.output(
+            input,
+            self._second_temp_file
+        )
+        # Overwrite output file
+        overwrite = ffmpeg.overwrite_output(
+            output
+        )
+        # Running command
+        ffmpeg.run(
+            stream_spec=overwrite,
+            quiet=True
+        )
+        # Changing main temp file format
+        self._main_temp_file = os.path.join(
+            self._temp_dir.name,
+            "main" + extension
+        )
+        # Saving result to main file
+        self._move_and_replace()

--- a/src/fastedit/io/Subtitles.py
+++ b/src/fastedit/io/Subtitles.py
@@ -1,3 +1,4 @@
+from typing import Union
 from fastedit.core.Base import _Base
 from fastedit.core.utils import _guess_file_type
 import ffmpeg
@@ -72,3 +73,52 @@ class Subtitles(_Base):
         )
         # Saving result to main file
         self._move_and_replace()
+
+    def _extract(
+        self,
+        start: Union[int, float],
+        end: Union[int, float]
+    ):
+        """
+        """
+        # Verifying parameters types
+        if not isinstance(start, (float, int)):
+            raise TypeError(
+                f"Expected 'start' to be of type 'float' or 'int', but got "
+                f"'{type(start).__name__}' instead."
+            )
+        if not isinstance(end, (float, int)):
+            raise TypeError(
+                f"Expected 'end' to be of type 'float' or 'int', but got "
+                f"'{type(start).__name__}' instead."
+            )
+        # Verifying parameters consistency
+        if not end > start:
+            raise ValueError(
+                f"Invalid 'end' value: 'end' must be strictly greater than "
+                f"'start'. Got start={start} and end={end}."
+            )
+        # Trimming input media
+        input = ffmpeg.input(
+            filename=self._main_temp_file,
+        )
+        # Defining output and codec copying
+        output = ffmpeg.output(
+            input,
+            self._second_temp_file,
+            ss=start,
+            to=end,
+            c="copy"
+        )
+        overwrite = ffmpeg.overwrite_output(
+            output
+        )
+        # Running command
+        ffmpeg.run(
+            stream_spec=overwrite,
+            quiet=True
+        )
+        # Returning new subtitles object
+        return Subtitles(
+            path=self._second_temp_file
+        )

--- a/src/fastedit/io/Video.py
+++ b/src/fastedit/io/Video.py
@@ -707,7 +707,6 @@ class Video(_Media):
                 vcodec="copy",
                 acodec="copy",
                 scodec=scodec,
-                ss=0,
                 t=media_duration
             )
         else:

--- a/src/fastedit/io/Video.py
+++ b/src/fastedit/io/Video.py
@@ -695,10 +695,14 @@ class Video(_Media):
         elif strategy == valid_strategies[1]:
             # Getting media duration
             media_metadata = self.metadata()
-            media_duration = media_metadata["duration"]
+            media_duration = float(media_metadata["duration"])
+            extracted_subtitles = subtitles._extract(
+                start=0,
+                end=media_duration
+            )
             # Adding soft subtitles
             input_subtitles = ffmpeg.input(
-                filename=subtitles._main_temp_file
+                filename=extracted_subtitles._main_temp_file
             )
             output = ffmpeg.output(
                 input,
@@ -706,8 +710,7 @@ class Video(_Media):
                 self._second_temp_file,
                 vcodec="copy",
                 acodec="copy",
-                scodec=scodec,
-                t=media_duration
+                scodec=scodec
             )
         else:
             raise NameError(

--- a/src/fastedit/io/Video.py
+++ b/src/fastedit/io/Video.py
@@ -686,14 +686,17 @@ class Video(_Media):
                 valid_positions[7]: 2,
                 valid_positions[8]: 3
             }
-            # Defining output
+            # Adding hard subtitles
             output = ffmpeg.output(
                 input,
                 self._second_temp_file,
                 vf=f"subtitles={subtitles._main_temp_file}:force_style='Alignment={position_mapping[position]}'"
             )
         elif strategy == valid_strategies[1]:
-            # Defining output
+            # Getting media duration
+            media_metadata = self.metadata()
+            media_duration = media_metadata["duration"]
+            # Adding soft subtitles
             input_subtitles = ffmpeg.input(
                 filename=subtitles._main_temp_file
             )
@@ -703,7 +706,9 @@ class Video(_Media):
                 self._second_temp_file,
                 vcodec="copy",
                 acodec="copy",
-                scodec=scodec
+                scodec=scodec,
+                ss=0,
+                to=media_duration
             )
         else:
             raise NameError(

--- a/src/fastedit/io/Video.py
+++ b/src/fastedit/io/Video.py
@@ -434,10 +434,14 @@ class Video(_Media):
             output
         )
         # Running command
-        ffmpeg.run(
-            stream_spec=overwrite,
-            quiet=True
-        )
+        try:
+            ffmpeg.run(
+                stream_spec=overwrite,
+                quiet=True
+            )
+        except ffmpeg.Error as error:
+            print(error.stderr)
+            print(error.stdout)
         # Saving result to main file
         self._move_and_replace()
 

--- a/src/fastedit/io/Video.py
+++ b/src/fastedit/io/Video.py
@@ -708,7 +708,7 @@ class Video(_Media):
                 acodec="copy",
                 scodec=scodec,
                 ss=0,
-                to=media_duration
+                t=media_duration
             )
         else:
             raise NameError(

--- a/tests/unit/video_test.py
+++ b/tests/unit/video_test.py
@@ -1,5 +1,6 @@
 from fastedit.io.Video import Video
 from fastedit.io.Audio import Audio
+from fastedit.io.Subtitles import Subtitles
 import ffmpeg
 import pytest
 import os
@@ -7,7 +8,9 @@ import os
 
 test_files = [
     "./media/test_video_with_audio.mp4",
-    "./media/test_audio.mp3"
+    "./media/test_audio.mp3",
+    "./media/test_subtitles.ass",
+    "./media/test_subtitles.srt"
 ]
 
 
@@ -988,5 +991,194 @@ def test_video_save_wrong_path_type():
     expected_error = (
         "Expected 'path' to be of type 'str', but got "
         "'int' instead."
+    )
+    assert str(error.value) == expected_error
+
+
+def test_video_add_subtitles_wrong_type_subtitles():
+    video = Video(test_files[0])
+    subtitles = 3
+    with pytest.raises(TypeError) as error:
+        video.add_subtitles(
+            subtitles=subtitles,
+            strategy="hard",
+            position="middle-center",
+        )
+    expected_error = (
+        "Expected 'subtitles' to be of type 'Subtitles', but got "
+        "'int' instead."
+    )
+    assert str(error.value) == expected_error
+
+
+def test_video_add_subtitles_wrong_type_strategy():
+    video = Video(test_files[0])
+    subtitles = Subtitles(test_files[2])
+    with pytest.raises(TypeError) as error:
+        video.add_subtitles(
+            subtitles=subtitles,
+            strategy=3,
+            position="middle-center",
+        )
+    expected_error = (
+        "Expected 'strategy' to be of type 'str', but got "
+        "'int' instead."
+    )
+    assert str(error.value) == expected_error
+
+
+def test_video_add_subtitles_wrong_type_position():
+    video = Video(test_files[0])
+    subtitles = Subtitles(test_files[2])
+    with pytest.raises(TypeError) as error:
+        video.add_subtitles(
+            subtitles=subtitles,
+            strategy="hard",
+            position=3,
+        )
+    expected_error = (
+        "Expected 'position' to be of type 'str', but got "
+        "'int' instead."
+    )
+    assert str(error.value) == expected_error
+
+
+def test_video_add_subtitles_wrong_type_scodec():
+    video = Video(test_files[0])
+    subtitles = Subtitles(test_files[2])
+    with pytest.raises(TypeError) as error:
+        video.add_subtitles(
+            subtitles=subtitles,
+            strategy="soft",
+            scodec=3
+        )
+    expected_error = (
+        "Expected 'scodec' to be of type 'str', but got "
+        "'int' instead."
+    )
+    assert str(error.value) == expected_error
+
+
+def test_video_add_subtitles_wrong_value_strategy():
+    video = Video(test_files[0])
+    subtitles = Subtitles(test_files[2])
+    with pytest.raises(ValueError) as error:
+        video.add_subtitles(
+            subtitles=subtitles,
+            strategy="test"
+        )
+    expected_error = (
+        "Invalid strategy 'test'. Expected one of: "
+        "hard, soft."
+    )
+    assert str(error.value) == expected_error
+
+
+def test_video_add_subtitles_wrong_value_position():
+    video = Video(test_files[0])
+    subtitles = Subtitles(test_files[2])
+    with pytest.raises(ValueError) as error:
+        video.add_subtitles(
+            subtitles=subtitles,
+            strategy="hard",
+            position="test"
+        )
+    expected_error = (
+        "Invalid position 'test'. Expected one of: "
+        "top-left, top-center, top-right, middle-left, middle-center, "
+        "middle-right, bottom-left, bottom-center, bottom-right."
+    )
+    assert str(error.value) == expected_error
+
+
+def test_video_add_subtitles_ass_strategy_hard():
+    video = Video(test_files[0])
+    subtitles = Subtitles(test_files[2])
+    video.add_subtitles(
+        subtitles=subtitles,
+        strategy="hard",
+        position="middle-center"
+    )
+    output = video.metadata()
+    assert output["format_name"] == "mov,mp4,m4a,3gp,3g2,mj2"
+    assert int(float(output["duration"])) == 15
+    assert len(output["streams"]) == 2
+    assert output["streams"][0]["codec_name"] == "h264"
+    assert output["streams"][0]["height"] == 1080
+    assert output["streams"][0]["width"] == 1920
+
+
+def test_video_add_subtitles_ass_strategy_soft():
+    video = Video(test_files[0])
+    subtitles = Subtitles(test_files[2])
+    video.add_subtitles(
+        subtitles=subtitles,
+        strategy="soft"
+    )
+    output = video.metadata()
+    assert output["format_name"] == "mov,mp4,m4a,3gp,3g2,mj2"
+    assert int(float(output["duration"])) == 15
+    assert len(output["streams"]) == 3
+    assert output["streams"][0]["codec_name"] == "h264"
+    assert output["streams"][0]["height"] == 1080
+    assert output["streams"][0]["width"] == 1920
+
+
+def test_video_add_subtitles_srt_strategy_hard():
+    video = Video(test_files[0])
+    subtitles = Subtitles(test_files[3])
+    video.add_subtitles(
+        subtitles=subtitles,
+        strategy="hard",
+        position="middle-center"
+    )
+    output = video.metadata()
+    assert output["format_name"] == "mov,mp4,m4a,3gp,3g2,mj2"
+    assert int(float(output["duration"])) == 15
+    assert len(output["streams"]) == 2
+    assert output["streams"][0]["codec_name"] == "h264"
+    assert output["streams"][0]["height"] == 1080
+    assert output["streams"][0]["width"] == 1920
+
+
+def test_video_add_subtitles_srt_strategy_soft():
+    video = Video(test_files[0])
+    subtitles = Subtitles(test_files[3])
+    video.add_subtitles(
+        subtitles=subtitles,
+        strategy="soft"
+    )
+    output = video.metadata()
+    assert output["format_name"] == "mov,mp4,m4a,3gp,3g2,mj2"
+    assert int(float(output["duration"])) == 15
+    assert len(output["streams"]) == 3
+    assert output["streams"][0]["codec_name"] == "h264"
+    assert output["streams"][0]["height"] == 1080
+    assert output["streams"][0]["width"] == 1920
+
+
+def test_video_add_subtitles_without_ffmpeg(monkeypatch):
+    # Mocking FFmpeg not installed
+    def mock_ffmpeg(*args, **kwargs):
+        raise ffmpeg.Error(
+            "ffmpeg",
+            "stdout",
+            "stderr"
+        )
+
+    video = Video(test_files[0])
+    subtitles = Subtitles(test_files[3])
+
+    # Replace ffmpeg.run by mocking
+    monkeypatch.setattr(ffmpeg, "run", mock_ffmpeg)
+
+    # Testing
+    with pytest.raises(ffmpeg.Error) as error:
+        video.add_subtitles(
+            subtitles=subtitles,
+            strategy="soft"
+        )
+    expected_error = (
+        "ffmpeg error (see stderr output for detail)"
     )
     assert str(error.value) == expected_error


### PR DESCRIPTION
- Added `add_subtitles` method to handle subtitles with strategies 'hard' (burned) or 'soft' (optional).
- Supports position customization (e.g., 'bottom-center', 'top-left') for 'hard' strategy.
- Supports subtitle codec customization for 'soft' strategy.